### PR TITLE
Added turn_text : shows the current player's turns

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "nuxt.isNuxtApp": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "nuxt.isNuxtApp": false
+}

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
+from gi.repository import Gtk
 import pygame as pg
 from anim import Animate
 import g
@@ -22,7 +23,6 @@ import sys
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
 
 
 # The main controller
@@ -61,6 +61,8 @@ class Main:
                     self.score = [0, 0]
                 if self.help_pos.collidepoint(pg.mouse.get_pos()):
                     self.show_help = not self.show_help
+        self.turn_text = pg.font.Font(None, 64).render(
+            ["O Turn", "", "X Turn"][self.frame.turn+1], True, g.WHITE)
 
     def draw_help(self):
         pg.draw.circle(
@@ -73,9 +75,11 @@ class Main:
             g.WIN.blit(
                 self.close_text,
                 (
-                    (3 * g.WIDTH + g.FRAME_GAP * 3 - 2 * self.close_text.get_width())
+                    (3 * g.WIDTH + g.FRAME_GAP * 3 -
+                     2 * self.close_text.get_width())
                     // 4,
-                    (g.HEIGHT * 0.5 - g.FRAME_GAP * 1.5 - self.close_text.get_height())
+                    (g.HEIGHT * 0.5 - g.FRAME_GAP *
+                     1.5 - self.close_text.get_height())
                     // 2,
                 ),
             )
@@ -108,7 +112,8 @@ class Main:
             g.WIN.blit(
                 self.question_text,
                 (
-                    (3 * g.WIDTH + g.FRAME_GAP * 3 - 2 * self.question_text.get_width())
+                    (3 * g.WIDTH + g.FRAME_GAP * 3 -
+                     2 * self.question_text.get_width())
                     // 4,
                     (
                         g.HEIGHT * 0.5
@@ -125,7 +130,16 @@ class Main:
             self.heading,
             (
                 (g.WIDTH - self.heading.get_width()) // 2,
-                (g.HEIGHT * 0.5 - g.FRAME_GAP * 1.5 - self.heading.get_height()) // 2,
+                (g.HEIGHT * 0.5 - g.FRAME_GAP * 1.5 -
+                 self.heading.get_height()) // 2,
+            ),
+        )
+        g.WIN.blit(
+            self.turn_text,
+            (
+                (g.WIDTH - g.FRAME_GAP * 3 - 2 * self.turn_text.get_width()) / 4,
+                (g.HEIGHT * 0.5 - g.FRAME_GAP * 1.5 -
+                 self.turn_text.get_height()) // 2,
             ),
         )
         self.frame.draw()
@@ -143,7 +157,8 @@ class Main:
         g.WIN.blit(
             scoreo,
             (
-                g.WIDTH - (g.WIDTH - g.FRAME_GAP * 3 + 2 * scorex.get_width()) / 4,
+                g.WIDTH - (g.WIDTH - g.FRAME_GAP * 3 +
+                           2 * scorex.get_width()) / 4,
                 (g.HEIGHT / 2 + g.FRAME_GAP / 4),
             ),
         )
@@ -181,7 +196,9 @@ class Main:
                 break
         g.init()
         pg.font.init()
-        self.heading = pg.font.Font(None, 96).render("Tic - Tac - Toe", True, g.WHITE)
+        self.heading = pg.font.Font(None, 96).render(
+            "Tic - Tac - Toe", True, g.WHITE)
+        self.turn_text = pg.font.Font(None, 64).render("X Turn", True, g.WHITE)
         self.reset_text = pg.font.Font(None, 56).render("Reset", True, g.WHITE)
         self.question_text = pg.font.Font(None, 72).render("?", True, g.WHITE)
         self.close_text = pg.font.Font(None, 64).render("X", True, g.WHITE)
@@ -212,10 +229,12 @@ class Main:
         )
         self.font = pg.font.Font(None, 72)
         self.cross_ui = Animate(self, color=g.ORANGE).cross(
-            ((g.WIDTH - g.FRAME_GAP * 3) / 4, g.HEIGHT / 2 - g.FRAME_GAP / 4), 43, 11
+            ((g.WIDTH - g.FRAME_GAP * 3) / 4,
+             g.HEIGHT / 2 - g.FRAME_GAP / 4), 43, 11
         )
         self.circle_ui = Animate(self, color=g.RED).circle(
-            (g.WIDTH - (g.WIDTH - g.FRAME_GAP * 3) / 4, g.HEIGHT / 2 - g.FRAME_GAP / 4),
+            (g.WIDTH - (g.WIDTH - g.FRAME_GAP * 3) /
+             4, g.HEIGHT / 2 - g.FRAME_GAP / 4),
             40,
             8,
         )

--- a/main.py
+++ b/main.py
@@ -61,8 +61,6 @@ class Main:
                     self.score = [0, 0]
                 if self.help_pos.collidepoint(pg.mouse.get_pos()):
                     self.show_help = not self.show_help
-        self.turn_text = pg.font.Font(None, 64).render(
-            ["O Turn", "", "X Turn"][self.frame.turn+1], True, g.WHITE)
 
     def draw_help(self):
         pg.draw.circle(
@@ -198,7 +196,8 @@ class Main:
         pg.font.init()
         self.heading = pg.font.Font(None, 96).render(
             "Tic - Tac - Toe", True, g.WHITE)
-        self.turn_text = pg.font.Font(None, 64).render("X Turn", True, g.WHITE)
+        self.turn_text = pg.font.Font(None, 64).render(
+            ["O Turn", "", "X Turn"][self.frame.turn+1], True, g.WHITE)
         self.reset_text = pg.font.Font(None, 56).render("Reset", True, g.WHITE)
         self.question_text = pg.font.Font(None, 72).render("?", True, g.WHITE)
         self.close_text = pg.font.Font(None, 64).render("X", True, g.WHITE)

--- a/main.py
+++ b/main.py
@@ -240,8 +240,6 @@ class Main:
             self.canvas.grab_focus()
 
         self.frame = Frame(self, (g.WIDTH / 2, g.HEIGHT / 2))
-        # self.turn_text = pg.font.Font(None, 64).render(
-        #     ["O Turn", "", "X Turn"][self.frame.turn+1], True, g.WHITE)
         self.clock = pg.time.Clock()
         while self.running:
             if self.journal:

--- a/main.py
+++ b/main.py
@@ -240,8 +240,8 @@ class Main:
             self.canvas.grab_focus()
 
         self.frame = Frame(self, (g.WIDTH / 2, g.HEIGHT / 2))
-        self.turn_text = pg.font.Font(None, 64).render(
-            ["O Turn", "", "X Turn"][self.frame.turn+1], True, g.WHITE)
+        # self.turn_text = pg.font.Font(None, 64).render(
+        #     ["O Turn", "", "X Turn"][self.frame.turn+1], True, g.WHITE)
         self.clock = pg.time.Clock()
         while self.running:
             if self.journal:
@@ -250,6 +250,8 @@ class Main:
                     Gtk.main_iteration()
 
             self.check_events()
+            self.turn_text = pg.font.Font(None, 64).render(
+            ["O Turn", "", "X Turn"][self.frame.turn+1], True, g.WHITE)
             self.draw()
             self.clock.tick(g.FPS)
         pg.display.quit()

--- a/main.py
+++ b/main.py
@@ -196,8 +196,6 @@ class Main:
         pg.font.init()
         self.heading = pg.font.Font(None, 96).render(
             "Tic - Tac - Toe", True, g.WHITE)
-        self.turn_text = pg.font.Font(None, 64).render(
-            ["O Turn", "", "X Turn"][self.frame.turn+1], True, g.WHITE)
         self.reset_text = pg.font.Font(None, 56).render("Reset", True, g.WHITE)
         self.question_text = pg.font.Font(None, 72).render("?", True, g.WHITE)
         self.close_text = pg.font.Font(None, 64).render("X", True, g.WHITE)
@@ -242,6 +240,8 @@ class Main:
             self.canvas.grab_focus()
 
         self.frame = Frame(self, (g.WIDTH / 2, g.HEIGHT / 2))
+        self.turn_text = pg.font.Font(None, 64).render(
+            ["O Turn", "", "X Turn"][self.frame.turn+1], True, g.WHITE)
         self.clock = pg.time.Clock()
         while self.running:
             if self.journal:


### PR DESCRIPTION
## Overview
Added a text in the activity frame which tells the current player's turn


## Description
I used the TicTacToe activity and noticed that there was no indication of whose turn it was. I reckoned that this was a very common feature for any TicTacToe game and though it'd be nice to have that feature on our sugar activity as well. 
This PR aims to add the aforementioned feature.



## Screenshots
![ScreenShot1](https://user-images.githubusercontent.com/96080203/215274383-6b4eb592-8b39-4e81-b1a5-ed33f18c2b04.jpg)
Screenshot before the game starts.


![ScreenShot2](https://user-images.githubusercontent.com/96080203/215274367-db063e34-a5b2-457e-8728-ced8c4683c45.jpg)
Screenshot after a turn.


![ScreenShot3](https://user-images.githubusercontent.com/96080203/215274340-421d827c-6edd-4fce-8c15-0d1fea7a0ee4.jpg)
Screenshot after a round ends.


## Tests
I have manually used the activity after my modifications and I have not encountered or noticed any user facing bugs in the newly added piece of code.

## Note
The second commit only removes the .vscode folder which is unnecessary and was added by my code editor
The first commit is the feature itself
