### PR TITLE
Fix stop button not working

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -34,7 +34,6 @@ from sugar3.graphics.toolbarbox import ToolbarBox
 from sugar3.activity.widgets import ActivityToolbarButton
 from sugar3.graphics.toolbutton import ToolButton
 from sugar3.activity.widgets import StopButton
-from sugar3.activity.widgets import DescriptionItem
 
 
 import sugargame.canvas
@@ -87,3 +86,6 @@ class TicTacToe(Activity):
 
     def write_file(self, file_path):
         self.game.write_file(file_path)
+
+    def close(self):
+        self.game.quit()

--- a/main.py
+++ b/main.py
@@ -45,6 +45,9 @@ class Main:
     def read_file(self, file_path):
         pass
 
+    def quit(self):
+        self.running = False
+
     def check_events(self):
         for event in pg.event.get():
             if event.type == pg.QUIT:


### PR DESCRIPTION
@chimosky Sometimes the stop button doesn't work (like while I was porting the activity to flatpak, or directly running through `sugar-activity3` command. This change will fix that.