### PR TITLE
Fix X and O are disappearing randomly

### DIFF
--- a/frame.py
+++ b/frame.py
@@ -74,7 +74,7 @@ class Frame:
                 # Spawn O or X
                 # Update the board
                 center = self.standard_to_cartesian(rect.center)
-                index = (1 - int(center[1] / self.gap), int(center[0] / self.gap) + 1)
+                index = (1 - round(center[1] / self.gap), round(center[0] / self.gap) + 1)
                 self.board[index[0]][index[1]] = self.turn
                 self.moves[index[0]][index[1]] = OX(self.main, self.turn, rect.center)
                 self.rects.remove(rect)


### PR DESCRIPTION
When the height of the pygame canvas is an odd number of pixels, weird glitches happen because int() is being used instead of round().